### PR TITLE
correct Rodrigues vector output format

### DIFF
--- a/Source/EMsoftOOLib/mod_so3.f90
+++ b/Source/EMsoftOOLib/mod_so3.f90
@@ -2342,9 +2342,9 @@ do i=1, cnt
     case('ro')
       io_real(1:4) = FZtmp%rod%r_copyd()
       if (io_real(4).eq.inftyd()) then
-        call Message%WriteValue('', io_real, 3, frm="(2(F17.9,' '),'infinity')",redirect=53)
+        call Message%WriteValue('', io_real, 3, frm="(3(F17.9,' '),'infinity')",redirect=53)
       else
-        call Message%WriteValue('', io_real, 4, frm="(2(F17.9,' '),F17.9)",redirect=53)
+        call Message%WriteValue('', io_real, 4, frm="(3(F17.9,' '),F17.9)",redirect=53)
       end if
     case('om')
       o = FZtmp%qu%qo()


### PR DESCRIPTION
Updated the formatting string in Message%WriteValue from "(2(F17.9,' '),F17.9)"  to "(3(F17.9,' '),F17.9)"  when writing Rodrigues vector into a file. This ensures consistent precision and alignment of the output values.