### PR TITLE
BUG: Fix EMsampler to FZ-reduce quaternions before averaging and store EM parameters

### DIFF
--- a/Source/EMsoftOOLib/program_mods/mod_sampler.f90
+++ b/Source/EMsoftOOLib/program_mods/mod_sampler.f90
@@ -544,7 +544,11 @@ end if
 
 do i=1,4
   inputquat(1:4,i) = meanquat(i)%get_quatd()
-end do  
+end do
+
+! initialize the local seed variables from the namelist parameters
+seed1 = enl%seed1
+seed2 = enl%seed2
 
 ! we'll do vMF sampling first and generate 8 orientation data sets 
 dictVMF = DirStat_T( DStype='VMF', PGnum=enl%pgnum )
@@ -560,6 +564,15 @@ do i=1,2      ! loop over the kappa concentration parameter values
     do k=1,enl%norientations 
       mu = qAR%getQuatfromArray(k)
       vMFquatarray(1:4,k,setcnt) = mu%get_quatd()
+    end do
+! FZ-reduce the sampled quaternions before averaging
+    do k=1,enl%norientations
+      mu = qAR%getQuatfromArray(k)
+      q = q_T( qdinp = mu%get_quatd() )
+      call SO%ReduceOrientationtoRFZ( q, qsym, r )
+      q = r%rq()
+      mu = Quaternion_T( qd = q%q_copyd() )
+      call qAR%insertQuatinArray(k, mu)
     end do
     io_int = (/ i, j /)
     call Message%WriteValue(' Averaging vMF data set ', io_int, 2)
@@ -613,6 +626,15 @@ do i=1,2      ! loop over the kappa concentration parameter values
       mu = qAR%getQuatfromArray(k)
       WATquatarray(1:4,k,setcnt) = mu%get_quatd()
     end do
+! FZ-reduce the sampled quaternions before averaging
+    do k=1,enl%norientations
+      mu = qAR%getQuatfromArray(k)
+      q = q_T( qdinp = mu%get_quatd() )
+      call SO%ReduceOrientationtoRFZ( q, qsym, r )
+      q = r%rq()
+      mu = Quaternion_T( qd = q%q_copyd() )
+      call qAR%insertQuatinArray(k, mu)
+    end do
     io_int = (/ i, j /)
     call Message%WriteValue(' Averaging WAT data set ', io_int, 2)
 ! and we might as well do the averaging at this point ...
@@ -660,6 +682,14 @@ if (hdferr.ne.0) call HDF%error_check('writeDatasetDoubleArray misor', hdferr)
 dataset = 'inputquat'
 hdferr = HDF%writeDatasetDoubleArray(dataset, inputquat, 4, 4)
 if (hdferr.ne.0) call HDF%error_check('writeDatasetDoubleArray inputquat', hdferr)
+
+dataset = 'NumEM'
+hdferr = HDF%writeDatasetInteger(dataset, 25)
+if (hdferr.ne.0) call HDF%error_check('writeDatasetInteger NumEM', hdferr)
+
+dataset = 'NumIter'
+hdferr = HDF%writeDatasetInteger(dataset, 30)
+if (hdferr.ne.0) call HDF%error_check('writeDatasetInteger NumIter', hdferr)
 
 call HDF%pop() 
 call HDF%pop() 


### PR DESCRIPTION
  The sampler_ subroutine had two issues:

  1. Local variables seed1/seed2 were never assigned from enl%seed1/enl%seed2, leaving them uninitialized. They are now properly initialized from the namelist parameters before use.

  2. Sampled quaternions were passed directly to EMforDS for averaging without first being reduced to the Rodrigues Fundamental Zone (RFZ). This produced reference averages that disagreed with EMorav (which does FZ-reduce) and with EbsdLib's C++ port of the same algorithm. Both vMF and Watson sampling loops now FZ-reduce via ReduceOrientationtoRFZ before averaging.

  Additionally, NumEM and NumIter are now written as scalar integer datasets
  in the HDF5 output (/EMData/Sampler/) so that downstream consumers can read
  the exact EM iteration parameters used to generate the reference data.